### PR TITLE
import logging on app.py. needed for ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /upload_dir
 /__pycache__
+app.log
+access.log
+

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 import ipfshttpclient
 import requests
 from contract import contract_ABI, contract_address
+import logging
 
 load_dotenv()
 


### PR DESCRIPTION
```
~/sentinel-ai/coordinator-node (master) $ Connected to IPFS v0.4.23

Connected to Web3 v5.2.0
Traceback (most recent call last):
  File "/usr/bin/gunicorn3", line 11, in <module>
    load_entry_point('gunicorn==19.7.1', 'console_scripts', 'gunicorn')()
  File "/usr/lib/python3/dist-packages/gunicorn/app/wsgiapp.py", line 74, in run
    WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
  File "/usr/lib/python3/dist-packages/gunicorn/app/base.py", line 203, in run
    super(Application, self).run()
  File "/usr/lib/python3/dist-packages/gunicorn/app/base.py", line 72, in run
    Arbiter(self).run()
  File "/usr/lib/python3/dist-packages/gunicorn/arbiter.py", line 60, in __init__
    self.setup(app)
  File "/usr/lib/python3/dist-packages/gunicorn/arbiter.py", line 120, in setup
    self.app.wsgi()
  File "/usr/lib/python3/dist-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/usr/lib/python3/dist-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/usr/lib/python3/dist-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/usr/lib/python3/dist-packages/gunicorn/util.py", line 377, in import_app
    __import__(module)
  File "/home/ubuntu/sentinel-ai/coordinator-node/app.py", line 198, in <module>
    gunicorn_logger = logging.getLogger('gunicorn.error')
NameError: name 'logging' is not defined

```

This error when started on Ubuntu env. Need explicit logging import.